### PR TITLE
Enable searching queries by title or description

### DIFF
--- a/quarry/web/query.py
+++ b/quarry/web/query.py
@@ -133,6 +133,16 @@ def query_runs_all():
         )
     else:
         session["recent_queries_link"] = url_for("query.query_runs_all")
+    # Handle search parameters
+    args = request.args
+    search_term = args.get("search_term")
+    search_parameter = ""
+    if search_term is not None:
+        search_parameter = f"search_term={search_term}"
+        queries = queries.filter(
+            Query.title.ilike(f"%{search_term}%")
+            | Query.description.ilike(f"%{search_term}%")
+        )
     limit = int(
         request.args.get(
             "limit", current_app.config.get("QUERY_RESULTS_PER_PAGE", 50)
@@ -152,6 +162,8 @@ def query_runs_all():
         queries=queries,
         prev_link=prev_link,
         next_link=next_link,
+        search_parameter=search_parameter,
+        search_term=search_term,
         queries_filter=queries_filter,
     )
 

--- a/quarry/web/static/css/query/list.css
+++ b/quarry/web/static/css/query/list.css
@@ -1,3 +1,12 @@
 .query-list-filters {
     margin-bottom: 10px;
 }
+
+.query-list-button {
+    padding: 6px 12px !important;
+}
+
+.query-search-container {
+    padding: 0px;
+    margin: 0px 0px 15px 0px;
+}

--- a/quarry/web/templates/query/list.html
+++ b/quarry/web/templates/query/list.html
@@ -5,13 +5,19 @@
 {% endblock %}
 {% block content %}
 <div id="content" class="container">
+    <form class="navbar-form navbar-left query-search-container" action="{{session.recent_queries_link}}" method="GET">
+        <div class="form-group">
+            <input type="text" name="search_term" class="form-control" placeholder="Find queries by term..." value="{{search_term or ''}}">
+            <button type="submit" class="btn btn-default query-list-button">Search</button>
+        </div>
+    </form>
     <div class="query-list-filters btn-group btn-group-sm pull-right" role="group">
-      <button type="button" class="btn btn-default{% if queries_filter == 'all' %} active{% endif %}">
-          <a href="/query/runs/all">All queries</a>
-      </button>
-      <button type="button" class="btn btn-default{% if queries_filter == 'published' %} active{% endif %}">
-          <a href="/query/runs/all?published=true">Published queries</a>
-      </button>
+        <button type="button" class="btn btn-default query-list-button{% if queries_filter == 'all' %} active{% endif %}">
+            <a href="/query/runs/all?{{search_parameter}}">All queries</a>
+        </button>
+        <button type="button" class="btn btn-default query-list-button{% if queries_filter == 'published' %} active{% endif %}">
+            <a href="/query/runs/all?published=true&{{search_parameter}}">Published queries</a>
+        </button>
     </div>
     <table class="table table-bordered table-hover">
         {% if queries %}
@@ -40,14 +46,14 @@
         </tbody>
     </table>
     <nav>
-      <ul class="pager">
-        <li class="previous{% if not prev_link %} disabled{% endif %}">
-            <a href="{{ prev_link or '#' }}">Previous</a>
-        </li>
-        <li class="next{% if not next_link %} disabled{% endif %}">
-            <a href="{{ next_link or '#' }}">Next</a>
-        </li>
-      </ul>
+        <ul class="pager">
+            <li class="previous{% if not prev_link %} disabled{% endif %}">
+                <a href="{{ prev_link or '#' }}">Previous</a>
+            </li>
+            <li class="next{% if not next_link %} disabled{% endif %}">
+                <a href="{{ next_link or '#' }}">Next</a>
+            </li>
+        </ul>
     </nav>
 </div>
 {% endblock %}

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -14,6 +14,7 @@ class TestQuery:
     @pytest.fixture(autouse=True)
     def setup_method(self, mocker, client):
         self.query_id = 66
+        self.query_title = "a query with a grand title"
         self.latest_rev_id = 88
         self.resultset_id = 1
         self.connection_id = 1
@@ -37,7 +38,7 @@ class TestQuery:
             latest_rev=r,
             description="fake query entry",
             user=u,
-            title="a query with a grand title",
+            title=self.query_title,
             last_touched=datetime.utcnow(),
         )
 
@@ -133,6 +134,12 @@ class TestQuery:
         assert b"extra query entry #2" in response.data
         assert b"extra query entry #7" not in response.data
         assert response.status_code == 200
+
+    def test_query_search_by_title(self, mocker):
+        response = self.client.get("/query/runs/all?search_term=%s" % self.query_title)
+
+        assert response.status_code == 200
+        assert response.data
 
     def test_output_query_meta(self, mocker):
         response = self.client.get("/query/%d/meta" % self.query_id)


### PR DESCRIPTION
This change enables a search functionality in Quarry and makes it possible to find previous queries based on terms included in query's title or description. The "Recent queries" page now features a Search box.

Bug: T90509