### PR TITLE
landing: Update ToU link/wording

### DIFF
--- a/quarry/web/templates/landing.html
+++ b/quarry/web/templates/landing.html
@@ -14,7 +14,7 @@
             <a class="btn btn-primary btn-lg" role="button" href="/query/new">New Query</a>
             {% else %}
             <a class="btn btn-primary btn-lg" role="button" href="/login?next=/">Login with Wikimedia</a>
-            <p id="login-tou-blurb">By logging in, you agree to the <a href="https://wikitech.wikimedia.org/wiki/Wikitech:Labs_Terms_of_use">Wikimedia Labs Terms of Use</a></p>
+            <p id="login-tou-blurb">By logging in, you agree to the <a href="https://wikitech.wikimedia.org/wiki/Wikitech:Cloud_Services_Terms_of_use">Wikimedia Cloud Services Terms of Use</a></p>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
Removes the last instance of "Labs Terms of Use" existing in the repo. The rest of the templates use the WMCS wording.