### PR TITLE
Remove DB suggestions ending with a semicolon 

### DIFF
--- a/quarry/web/api.py
+++ b/quarry/web/api.py
@@ -232,7 +232,7 @@ def get_dbs() -> Response:
             {
                 "dbs": list(
                     set(
-                        db_result[-1].strip()
+                        db_result[-1].strip().rstrip(";")
                         for db_result in known_dbs
                         # the db data might be NULL, empty strings or spaces+tabs only so this helps a bit to show only
                         # likely names


### PR DESCRIPTION
The list of DBs suggested by Quarry (accessible at https://quarry.wmcloud.org/api/dbs)
contains DB names that end with a semicolon. Usually, these are duplicate entries for
another suggestion with a semicolon (e.g., both "enwiki_p" and "enwiki_p;" are in the
list). While this list has other issues too, removing these duplicate entries that end with
a semicolon can greatly improve the data quality in this list.

Bug: T289943