### PR TITLE
Handle pymysql OperationalError in worker script

### DIFF
--- a/helm-quarry/values.yaml
+++ b/helm-quarry/values.yaml
@@ -1,7 +1,7 @@
 web:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-47 # web tag managed by github actions
+  tag: pr-48 # web tag managed by github actions
 
 worker:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-47 # worker tag managed by github actions
+  tag: pr-48 # worker tag managed by github actions

--- a/helm-quarry/values.yaml
+++ b/helm-quarry/values.yaml
@@ -1,7 +1,7 @@
 web:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-48 # web tag managed by github actions
+  tag: pr-42 # web tag managed by github actions
 
 worker:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-48 # worker tag managed by github actions
+  tag: pr-42 # worker tag managed by github actions

--- a/quarry/web/worker.py
+++ b/quarry/web/worker.py
@@ -152,7 +152,9 @@ def run_query(query_run_id):
         qrun.status = QueryRun.STATUS_FAILED
         conn.session.add(qrun)
         conn.session.commit()
-        celery_log.error("OperationalError for qrun:%s, error: %s", qrun.id, str(e))
+        celery_log.error(
+            "OperationalError for qrun:%s, error: %s", qrun.id, str(e)
+        )
     finally:
         conn.close_session()
         del repl.connection

--- a/quarry/web/worker.py
+++ b/quarry/web/worker.py
@@ -151,7 +151,7 @@ def run_query(query_run_id):
             write_error(qrun, e.args[1])
     except Exception as e:
         qrun.status = QueryRun.STATUS_FAILED
-        qrun.extra_info = json.dumps({"error": e.args[1]})
+        qrun.extra_info = json.dumps({"error": str(e)})
         conn.session.add(qrun)
         conn.session.commit()
         tb_str = "".join(

--- a/quarry/web/worker.py
+++ b/quarry/web/worker.py
@@ -148,6 +148,11 @@ def run_query(query_run_id):
             celery_log.info("Stopped run for qrun:%s", qrun.id)
         else:
             write_error(qrun, e.args[1])
+    except pymysql.err.OperationalError as e:
+        qrun.status = QueryRun.STATUS_FAILED
+        conn.session.add(qrun)
+        conn.session.commit()
+        celery_log.error("OperationalError for qrun:%s, error: %s", qrun.id, str(e))
     finally:
         conn.close_session()
         del repl.connection


### PR DESCRIPTION
An exception clause for pymysql's OperationalError has been included in the worker script. Query run (qrun) status is now updated to 'failed' and logged for operational exceptions, thus improving error handling and traceability.

Bug: T365136