### PR TITLE
Fix bug causing wiki replica queries going to ToolsDb

### DIFF
--- a/helm-quarry/values.yaml
+++ b/helm-quarry/values.yaml
@@ -1,7 +1,7 @@
 web:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-46 # web tag managed by github actions
+  tag: pr-47 # web tag managed by github actions
 
 worker:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-46 # worker tag managed by github actions
+  tag: pr-47 # worker tag managed by github actions

--- a/quarry/web/replica.py
+++ b/quarry/web/replica.py
@@ -21,12 +21,15 @@ class Replica:
             self.is_tools_db = True
             self.database_p = self.dbname
         elif self.dbname == "meta" or self.dbname == "meta_p":
+            self.is_tools_db = False
             self.database_name = "s7"
             self.database_p = "meta_p"
         elif self.dbname == "centralauth" or self.dbname == "centralauth_p":
+            self.is_tools_db = False
             self.database_name = "s7"
             self.database_p = "centralauth_p"
         else:
+            self.is_tools_db = False
             self.database_name = (
                 self.dbname
                 if not self.dbname.endswith("_p")


### PR DESCRIPTION
The Replica object is instantiated just once per worker, as opposed to once per query run that I previously thought was the case.

This means self.is_tools_db needs to be explicitly set to `False` when we are querying wiki replicas, as it may have previously been set to `True` while querying tools db.

Bug: T365374