### PR TITLE
Enable pool_pre_ping to eliminate db connection reset errors

### DIFF
--- a/helm-quarry/values.yaml
+++ b/helm-quarry/values.yaml
@@ -1,7 +1,7 @@
 web:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-49 # web tag managed by github actions
+  tag: pr-51 # web tag managed by github actions
 
 worker:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-49 # worker tag managed by github actions
+  tag: pr-51 # worker tag managed by github actions

--- a/quarry/web/connections.py
+++ b/quarry/web/connections.py
@@ -17,9 +17,7 @@ class Connections(object):
                 self.config["DB_NAME"],
             )
 
-            # Recycle connections after 10 mins, since mysql does not
-            # like it otherwise
-            self._db_engine = create_engine(url, pool_recycle=600)
+            self._db_engine = create_engine(url, pool_size=12, pool_pre_ping=True)
 
         return self._db_engine
 


### PR DESCRIPTION
This sends a "SELECT 1" to the Trove db every time a db connection is retrieved from the pool. Although it adds slight latency, it is common in db pooling setups and should be worth it as it would eliminate all connection reset errors.

Also set pool_size=12, increasing it from the default 5. We have 10 pods (8 web + 2 worker), so total 120 connections which is very reasonable, as Quarry is the only user of this db.

Bug: T367464