### PR TITLE
Restore EXPLAIN capability

### DIFF
--- a/helm-quarry/values.yaml
+++ b/helm-quarry/values.yaml
@@ -1,7 +1,7 @@
 web:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-52 # web tag managed by github actions
+  tag: pr-53 # web tag managed by github actions
 
 worker:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-52 # worker tag managed by github actions
+  tag: pr-53 # worker tag managed by github actions

--- a/quarry/web/query.py
+++ b/quarry/web/query.py
@@ -187,13 +187,9 @@ def output_query_meta(query_id):
     )
 
 
-# mdipietro 2021/08/04 couldn't get the connection to work here
-# very possibly just not understanding it. Though a:
-# g.replica.connection = <db>
-# line might help if indeed it isn't working
-# noted in T288170
-@query_blueprint.route("/explain/<int:connection_id>")
-def output_explain(connection_id):
+@query_blueprint.route("/explain/<string:db_name>/<int:connection_id>")
+def output_explain(db_name, connection_id):
+    g.replica.connection = db_name
     cur = g.replica.connection.cursor()
     try:
         cur.execute("SHOW EXPLAIN FOR %d;" % connection_id)

--- a/quarry/web/static/js/query/view.js
+++ b/quarry/web/static/js/query/view.js
@@ -264,7 +264,7 @@ $( function () {
 				document.getElementById( 'stop-code' ).style.visibility = 'hidden';
 			}
 			$( '#show-explain' ).off().click( function () {
-				$.get( '/explain/' + data.extra.connection_id ).done( function ( data ) {
+				$.get( '/explain/' + $( '#query-db' ).val() + '/' + data.extra.connection_id ).done( function ( data ) {
 					var $table = $( '#explain-results-table' );
 					if ( !$table.length ) {
 						$table = $( '<table>' ).attr( {

--- a/quarry/web/static/templates/compiled.js
+++ b/quarry/web/static/templates/compiled.js
@@ -140,26 +140,26 @@ output += "\nThis query was stopped\n";
 else {
 if(runtime.contextOrFrameLookup(context, frame, "status") == "running") {
 output += "\nThis query is currently executing...\n";
-if(runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "extra")),"connection_id")) {
-output += "\n<!--<button id=\"show-explain\" type=\"button\" class=\"btn btn-default btn-xs\">Explain</button>-->\n";
+;
+}
+;
+}
+;
+}
+;
+}
 ;
 }
 output += "\n";
-;
-}
-;
-}
-;
-}
-;
-}
+if(runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "extra")),"connection_id")) {
+output += "\n<button id=\"show-explain\" type=\"button\" class=\"btn btn-default btn-xs\">Explain</button>\n";
 ;
 }
 output += "\n";
 if(runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "extra")),"replag")) {
-output += "\n<div class=\"alert alert-warning\">\n  <h4 class=\"alert-heading\">Replication lag</h4>\n  <p class=\"mb-0\">The database on which this query was executed has a <a href=\"https://replag.toolforge.org/\">synchronization delay</a> with the wiki.\n      This can be caused by maintenance or incident on database, and should be resolved soon.<br>\n      The modifications that was made in last <b>";
+output += "\n<div class=\"alert alert-warning\">\n  <h4 class=\"alert-heading\">Replication lag</h4>\n  <p class=\"mb-0\">The database on which this query was executed has a <a href=\"https://replag.toolforge.org/\">synchronization delay</a> with the wiki.\n      This can be caused by maintenance or a database incident, and should be resolved soon.<br>\n      Modifications that were made in the last <b>";
 output += runtime.suppressValue(runtime.memberLookup((runtime.contextOrFrameLookup(context, frame, "extra")),"replag"), env.opts.autoescape);
-output += "</b> on the wiki are not taken into account in results bellow.<br>\n</div>\n";
+output += "</b> on the wiki are not taken into account in the results below.<br>\n</div>\n";
 ;
 }
 output += "\n";

--- a/quarry/web/static/templates/query-status.html
+++ b/quarry/web/static/templates/query-status.html
@@ -9,9 +9,9 @@ This query is waiting to be executed
 This query was stopped
 {% elif status == 'running' %}
 This query is currently executing...
-{% if extra.connection_id %}
-<!--<button id="show-explain" type="button" class="btn btn-default btn-xs">Explain</button>-->
 {% endif %}
+{% if extra.connection_id %}
+<button id="show-explain" type="button" class="btn btn-default btn-xs">Explain</button>
 {% endif %}
 {% if extra.replag %}
 <div class="alert alert-warning">


### PR DESCRIPTION
The explain endpoint now takes an additional db_name param, so that we can figure out the replica host to which the explain query should be sent.

Bug: T205214