### PR TITLE
metrics: Replace custom concatenation logic with two endpoints

### DIFF
--- a/quarry/web/metrics.py
+++ b/quarry/web/metrics.py
@@ -1,11 +1,9 @@
-from functools import wraps
-
-from flask import request
-from prometheus_client.exposition import choose_encoder
+from prometheus_client import make_wsgi_app
 from prometheus_client.metrics_core import GaugeMetricFamily
 from prometheus_client.registry import CollectorRegistry
 from prometheus_flask_exporter import PrometheusMetrics
 from sqlalchemy import func
+from werkzeug.middleware.dispatcher import DispatcherMiddleware
 
 from quarry.web.connections import Connections
 from quarry.web.models.queryrun import QueryRun
@@ -29,40 +27,12 @@ class QuarryQueryRunStatusCollector:
             labels=["status"],
         )
 
-        for (status_id, query_count) in queries_per_status:
+        for status_id, query_count in queries_per_status:
             metric_family.add_metric(
                 [QueryRun.STATUS_MESSAGES[status_id]], query_count
             )
 
         yield metric_family
-
-
-def add_custom_metrics(custom_registry: CollectorRegistry):
-    """
-    Add metrics that we load directly from the database in a way that it works
-    even in a 'multiproc' environment like what we do on production with uWSGI.
-    """
-
-    def wrapper(f):
-        @wraps(f)
-        def middleware(*args, **kwargs):
-            # Get metrics from the flask exporter
-            data, status, headers = f(*args, **kwargs)
-            if status != 200:
-                return data, status, headers
-
-            # Add our "custom" metrics (like amount of queries per status),
-            # without consulting the multiproc handler. Those metrics are
-            # generated at /metrics request time, not during normal flask
-            # request processing.
-            generate_latest, _ = choose_encoder(request.headers.get("Accept"))
-            data += generate_latest(custom_registry)
-
-            return data, status, headers
-
-        return middleware
-
-    return wrapper
 
 
 def metrics_init_app(app):
@@ -74,13 +44,19 @@ def metrics_init_app(app):
     custom_registry = CollectorRegistry()
     custom_registry.register(QuarryQueryRunStatusCollector(app))
 
+    app.wsgi_app = DispatcherMiddleware(
+        app.wsgi_app,
+        {
+            "/app/metrics": make_wsgi_app(custom_registry),
+        },
+    )
+
     # This will automatically use PROMETHEUS_MULTIPROC_DIR if specified,
     # so metrics in production with multiple uwsgi workers work properly.
     # Also note, the prometheus exporter package will not do anything if Flask
     # is in debug mode, unless the env variable DEBUG_METRICS is set.
     metrics = PrometheusMetrics.for_app_factory(
         metrics_endpoint="/metrics",
-        metrics_decorator=add_custom_metrics(custom_registry),
         # track metrics per route pattern, not per individual url
         group_by="url_rule",
     )


### PR DESCRIPTION
The current logic tries to concatenate responses from
prometheus-flask-exporter (providing metrics for that individual app
instance) and for the custom Quarry metrics (which reference things from
the database and so are global). That does not work, since unlike the
simple text format, the binary OTel format used in production does not
allow concatenating responses like that. In addition the model where
those two are combined was designed when there only was a single
instance of Quarry so scraping both worker-specific and global metrics
from the same endpoint was acceptable.

Instead split the app to use two endpoints; /metrics continues to be the
prometheus-flask-exporter one that should be scraped per worker
(although I'm not quite sure how to do that with metricsinfra and the
Trove cluster) and /app/metrics provides the app-level metrics that
should only have one Prometheus target for it.

Additionally, by scraping the app metrics via the quarry.wmcloud.org
service name and proxy, we can use the up metric for that target to
provide alerting in case Quarry is entirely down for users.

Bug: T392138
Change-Id: Id4aa84d43976630cf722c0932937e8ddd85b07b1
