### PR TITLE
helm: Deploy Redis Prometheus exporter

### DIFF
--- a/helm-quarry/templates/redis_exporter_service.yaml
+++ b/helm-quarry/templates/redis_exporter_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-exporter
+  labels:
+    app: redis
+spec:
+  ports:
+    - name: web
+      port: 9121
+      nodePort: 9121
+      protocol: TCP
+      targetPort: 9121
+  selector:
+    app: redis
+  type: NodePort

--- a/helm-quarry/templates/redis_statefulset.yaml
+++ b/helm-quarry/templates/redis_statefulset.yaml
@@ -24,6 +24,23 @@ spec:
               name: redis-data
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
+          ports:
+            - containerPort: 6379
+        - name: redis-exporter
+          image: {{ .Values.redis.exporter.image }}
+          securityContext:
+            runAsUser: 59000
+            runAsGroup: 59000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          ports:
+            - containerPort: 9121
       volumes:
         - name: redis-data
           emptyDir:

--- a/helm-quarry/values.yaml
+++ b/helm-quarry/values.yaml
@@ -28,3 +28,5 @@ redis:
     limits:
       memory: "512Mi"
       cpu: "250m"
+  exporter:
+    image: quay.io/oliver006/redis_exporter:v1.74.0

--- a/helm-quarry/values.yaml
+++ b/helm-quarry/values.yaml
@@ -1,6 +1,6 @@
 web:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-89 # web tag managed by github actions
+  tag: pr-90 # web tag managed by github actions
   resources:
     requests:
       memory: "300Mi"
@@ -11,7 +11,7 @@ web:
 
 worker:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-89 # worker tag managed by github actions
+  tag: pr-90 # worker tag managed by github actions
   resources:
     requests:
       memory: "400Mi"


### PR DESCRIPTION
We want to get some insight into how the Redis server here is doing
since it's been relatively unstable recently. Deploy a Prometheus
exporter here, to be scraped by metricsinfra Prometheus.

Bug: T396771
Change-Id: I50d6eb5d6fd83a0ec8c2e9c16bd7837c8ab09396
