### PR TITLE
api: Fix resetting a query title

### DIFF
--- a/helm-quarry/values.yaml
+++ b/helm-quarry/values.yaml
@@ -1,6 +1,6 @@
 web:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-95 # web tag managed by github actions
+  tag: pr-96 # web tag managed by github actions
   resources:
     requests:
       memory: "300Mi"
@@ -11,7 +11,7 @@ web:
 
 worker:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-95 # worker tag managed by github actions
+  tag: pr-96 # worker tag managed by github actions
   resources:
     requests:
       memory: "400Mi"

--- a/quarry/web/api.py
+++ b/quarry/web/api.py
@@ -74,7 +74,10 @@ def api_set_meta() -> Tuple[Union[str, Response], int]:
         return "Authorization denied", 403
 
     if "title" in request.form:
-        query.title = request.form["title"]
+        title = request.form["title"]
+        if not title.strip():
+            title = None
+        query.title = title
     if "published" in request.form:
         query.published = request.form["published"] == "1"
     if "description" in request.form:


### PR DESCRIPTION
When removing a query title, make sure it's represented as null in the
database, and not as an empty string. Otherwise it'll be impossible to
click in the various lists and otherwise break stuff.

Change-Id: I8f4d22d99e9a692105c23a9ad40214eb52923a61
