### PR TITLE
Fix CI: pin black to the version it actually runs

### DIFF
--- a/helm-quarry/values.yaml
+++ b/helm-quarry/values.yaml
@@ -1,6 +1,6 @@
 web:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-96 # web tag managed by github actions
+  tag: pr-100 # web tag managed by github actions
   resources:
     requests:
       memory: "300Mi"
@@ -11,7 +11,7 @@ web:
 
 worker:
   repository: 'quay.io/wikimedia-quarry/quarry'
-  tag: pr-96 # worker tag managed by github actions
+  tag: pr-100 # worker tag managed by github actions
   resources:
     requests:
       memory: "400Mi"

--- a/quarry/web/models/base.py
+++ b/quarry/web/models/base.py
@@ -1,4 +1,3 @@
 from sqlalchemy.ext.declarative import declarative_base
 
-
 Base = declarative_base()

--- a/quarry/web/utils/__init__.py
+++ b/quarry/web/utils/__init__.py
@@ -1,6 +1,5 @@
 import re
 
-
 VALID_DB_NAMES = re.compile(
     r"^(?:(?:(?:centralauth|meta|[0-9a-z_]*wik[a-z]+)(?:_p)?)|quarry(?:_p)?|s\d+__\w+_p)$"
 )

--- a/quarry/web/worker.py
+++ b/quarry/web/worker.py
@@ -16,7 +16,6 @@ from .replica import Replica
 from .utils import monkey as _unused  # noqa: F401
 from .webhelpers import get_pretty_delay
 
-
 celery_log = get_task_logger(__name__)
 
 celery = Celery("quarry.web.worker")

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,6 @@ pytest-cov
 pytest-mock
 pytest-redis
 mock-alchemy
-black==20.8b0
 mypy==0.981
 types-redis
 types-requests

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ skipsdist = True
 skip-missing-interpreters = False
 
 [flake8]
-exclude = bin,lib,include,.venv,.tox,dist,doc,build,*.egg
+exclude = bin,lib,include,.venv,.tox,dist,doc,build,*.egg,node_modules
 max-line-length = 120
 
 [mypy]
@@ -25,7 +25,9 @@ deps = -rtest-requirements.txt
 
 [testenv:py3-black]
 commands = black --check --diff quarry/web/
-deps = black
+# Pin black: an unpinned version turns CI red whenever black changes its
+# formatting upstream, with no change to this repository.
+deps = black==26.5.1
 
 [testenv:py3-mypy]
 commands = mypy quarry --config-file tox.ini


### PR DESCRIPTION
## The problem

`tox.ini` declares the black environment as:

```ini
[testenv:py3-black]
commands = black --check --diff quarry/web/
deps = black
```

Because this is unpinned, every CI run installs whatever black is newest on PyPI that day — currently **26.5.1**.  This results in CI going red in precisely the way the initial tox.ini comment warned against, just by a different mechanism.

This PR pins black for tox and does a slight reformat (blank lines) for the latest version.

It also drops black from `test-requirements.txt because it was currently a no-op.

Also add `node_modules` to the flake8 exclude to avoid errors running `tox` locally after building the frontend\

## AI disclosure

This patch was written with AI assistance (Claude Code), per [Using AI in MediaWiki patches](https://www.mediawiki.org/wiki/Using_AI_in_MediaWiki_patches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Manually reviewed by @audiodude.